### PR TITLE
Feature/centralized state reducers

### DIFF
--- a/multiagenticswarm/core/state.py
+++ b/multiagenticswarm/core/state.py
@@ -1,0 +1,68 @@
+from typing import TypedDict, List, Dict, Any, Optional
+import json
+
+class Message(TypedDict):
+    """
+    Represents a single message in an agent's conversation history or inter-agent communication.
+    """
+    role: str           # e.g., "user", "agent", "system"
+    content: str        # The message text/content
+    timestamp: float    # Unix timestamp of when the message was sent
+
+class AgentState(TypedDict, total=False):
+    """
+    State for a single agent.
+
+    Fields:
+        agent_id: Unique identifier for the agent.
+        name: Human-readable name.
+        messages: Conversation history (list of Message).
+        outputs: List of outputs/results produced by the agent.
+        progress: Progress as a float (0.0-1.0 or percent).
+        tool_permissions: List of tool names the agent can use.
+        tool_results: Results from tool calls.
+        collaboration_context: Shared context/rules for collaboration.
+        inter_agent_comm: Messages to/from other agents.
+        memory_working: Working memory (short-term, task-specific).
+        memory_short_term: Short-term memory (recent context).
+        updates: General updates/events (replaces file writes).
+    """
+    agent_id: str
+    name: str
+    messages: List[Message]
+    outputs: List[Any]
+    progress: float
+    tool_permissions: List[str]
+    tool_results: Dict[str, Any]
+    collaboration_context: Dict[str, Any]
+    inter_agent_comm: List[Message]
+    memory_working: List[Any]
+    memory_short_term: List[Any]
+    updates: List[Any]
+
+class SystemState(TypedDict, total=False):
+    """
+    State for the entire multi-agent system.
+
+    Fields:
+        agents: Mapping of agent_id to AgentState.
+        global_context: Global context/rules for the system.
+        progress_board: List of progress updates (replaces ProgressBoard file).
+        updates: General system updates/events.
+    """
+    agents: Dict[str, AgentState]
+    global_context: Dict[str, Any]
+    progress_board: List[Any]
+    updates: List[Any]
+
+def serialize_state(state: SystemState) -> str:
+    """
+    Serialize the system state to a JSON string.
+    """
+    return json.dumps(state)
+
+def deserialize_state(state_str: str) -> SystemState:
+    """
+    Deserialize the system state from a JSON string.
+    """
+    return json.loads(state_str)

--- a/multiagenticswarm/core/state_reducers.py
+++ b/multiagenticswarm/core/state_reducers.py
@@ -1,0 +1,49 @@
+from typing import List, Any
+from .state import AgentState, Message, SystemState
+
+def add_message(state: AgentState, message: Message) -> AgentState:
+    new_state = state.copy()
+    messages = list(new_state.get("messages", []))
+    messages.append(message)
+    new_state["messages"] = messages
+    return new_state
+
+def merge_outputs(state: AgentState, new_outputs: List[Any]) -> AgentState:
+    new_state = state.copy()
+    outputs = list(new_state.get("outputs", []))
+    outputs.extend(new_outputs)
+    new_state["outputs"] = outputs
+    return new_state
+
+def update_progress(state: AgentState, progress: float) -> AgentState:
+    new_state = state.copy()
+    new_state["progress"] = progress
+    return new_state
+
+def add_tool_result(state: AgentState, tool_name: str, result: Any) -> AgentState:
+    new_state = state.copy()
+    tool_results = dict(new_state.get("tool_results", {}))
+    tool_results[tool_name] = result
+    new_state["tool_results"] = tool_results
+    return new_state
+
+def add_inter_agent_message(state: AgentState, message: Message) -> AgentState:
+    new_state = state.copy()
+    comms = list(new_state.get("inter_agent_comm", []))
+    comms.append(message)
+    new_state["inter_agent_comm"] = comms
+    return new_state
+
+def add_update(state: AgentState, update: Any) -> AgentState:
+    new_state = state.copy()
+    updates = list(new_state.get("updates", []))
+    updates.append(update)
+    new_state["updates"] = updates
+    return new_state
+
+def add_agent(system_state: SystemState, agent_id: str, agent_state: AgentState) -> SystemState:
+    new_state = system_state.copy()
+    agents = dict(new_state.get("agents", {}))
+    agents[agent_id] = agent_state
+    new_state["agents"] = agents
+    return new_state


### PR DESCRIPTION
Centralized State Reducers for Agent State Management
What
Added a set of reducer functions in [state_reducers.py]) for updating and merging agent and system state in a type-safe, functional way.
Reducers include:
[add_message]:  (add a message to an agent’s history)
[merge_outputs]:  (merge outputs/results)
[update_progress]:  (update agent progress)
[add_tool_result]:  (add/update tool results)
[add_inter_agent_message]:  (add inter-agent communication)
[add_update]:  (add a general update/event)
[add_agent]:  (add or update an agent in the system state)
All reducers return new state objects, supporting immutable state updates.

Why
Moves the codebase toward a centralized, in-memory state management approach.
Eliminates the need for file-based agent communication and progress tracking.
Enables type safety, easier debugging, and future checkpointing.
Prepares the system for scalable, graph-based agent workflows.

Testing
Unit tests for all reducers have been written and pass successfully.
Serialization and deserialization of system state have also been tested.

Next Steps
Integrate these reducers into agents and ProgressBoard.
Refactor/remove file I/O for agent communication and progress tracking.
Continue migration to fully centralized state management.


Please review and let me know if you have any feedback or suggestions!