### PR TITLE
Test/state reducers

### DIFF
--- a/multiagenticswarm/core/state.py
+++ b/multiagenticswarm/core/state.py
@@ -1,0 +1,68 @@
+from typing import TypedDict, List, Dict, Any, Optional
+import json
+
+class Message(TypedDict):
+    """
+    Represents a single message in an agent's conversation history or inter-agent communication.
+    """
+    role: str           # e.g., "user", "agent", "system"
+    content: str        # The message text/content
+    timestamp: float    # Unix timestamp of when the message was sent
+
+class AgentState(TypedDict, total=False):
+    """
+    State for a single agent.
+
+    Fields:
+        agent_id: Unique identifier for the agent.
+        name: Human-readable name.
+        messages: Conversation history (list of Message).
+        outputs: List of outputs/results produced by the agent.
+        progress: Progress as a float (0.0-1.0 or percent).
+        tool_permissions: List of tool names the agent can use.
+        tool_results: Results from tool calls.
+        collaboration_context: Shared context/rules for collaboration.
+        inter_agent_comm: Messages to/from other agents.
+        memory_working: Working memory (short-term, task-specific).
+        memory_short_term: Short-term memory (recent context).
+        updates: General updates/events (replaces file writes).
+    """
+    agent_id: str
+    name: str
+    messages: List[Message]
+    outputs: List[Any]
+    progress: float
+    tool_permissions: List[str]
+    tool_results: Dict[str, Any]
+    collaboration_context: Dict[str, Any]
+    inter_agent_comm: List[Message]
+    memory_working: List[Any]
+    memory_short_term: List[Any]
+    updates: List[Any]
+
+class SystemState(TypedDict, total=False):
+    """
+    State for the entire multi-agent system.
+
+    Fields:
+        agents: Mapping of agent_id to AgentState.
+        global_context: Global context/rules for the system.
+        progress_board: List of progress updates (replaces ProgressBoard file).
+        updates: General system updates/events.
+    """
+    agents: Dict[str, AgentState]
+    global_context: Dict[str, Any]
+    progress_board: List[Any]
+    updates: List[Any]
+
+def serialize_state(state: SystemState) -> str:
+    """
+    Serialize the system state to a JSON string.
+    """
+    return json.dumps(state)
+
+def deserialize_state(state_str: str) -> SystemState:
+    """
+    Deserialize the system state from a JSON string.
+    """
+    return json.loads(state_str)

--- a/multiagenticswarm/core/state_reducers.py
+++ b/multiagenticswarm/core/state_reducers.py
@@ -1,0 +1,49 @@
+from typing import List, Any
+from .state import AgentState, Message, SystemState
+
+def add_message(state: AgentState, message: Message) -> AgentState:
+    new_state = state.copy()
+    messages = list(new_state.get("messages", []))
+    messages.append(message)
+    new_state["messages"] = messages
+    return new_state
+
+def merge_outputs(state: AgentState, new_outputs: List[Any]) -> AgentState:
+    new_state = state.copy()
+    outputs = list(new_state.get("outputs", []))
+    outputs.extend(new_outputs)
+    new_state["outputs"] = outputs
+    return new_state
+
+def update_progress(state: AgentState, progress: float) -> AgentState:
+    new_state = state.copy()
+    new_state["progress"] = progress
+    return new_state
+
+def add_tool_result(state: AgentState, tool_name: str, result: Any) -> AgentState:
+    new_state = state.copy()
+    tool_results = dict(new_state.get("tool_results", {}))
+    tool_results[tool_name] = result
+    new_state["tool_results"] = tool_results
+    return new_state
+
+def add_inter_agent_message(state: AgentState, message: Message) -> AgentState:
+    new_state = state.copy()
+    comms = list(new_state.get("inter_agent_comm", []))
+    comms.append(message)
+    new_state["inter_agent_comm"] = comms
+    return new_state
+
+def add_update(state: AgentState, update: Any) -> AgentState:
+    new_state = state.copy()
+    updates = list(new_state.get("updates", []))
+    updates.append(update)
+    new_state["updates"] = updates
+    return new_state
+
+def add_agent(system_state: SystemState, agent_id: str, agent_state: AgentState) -> SystemState:
+    new_state = system_state.copy()
+    agents = dict(new_state.get("agents", {}))
+    agents[agent_id] = agent_state
+    new_state["agents"] = agents
+    return new_state

--- a/multiagenticswarm/core/test_state_reducers.py
+++ b/multiagenticswarm/core/test_state_reducers.py
@@ -1,0 +1,61 @@
+import unittest
+from datetime import datetime
+from .state import AgentState, Message, SystemState, serialize_state, deserialize_state
+from .state_reducers import (
+    add_message, merge_outputs, update_progress, add_tool_result,
+    add_inter_agent_message, add_update, add_agent
+)
+
+class TestStateReducers(unittest.TestCase):
+    def test_add_message(self):
+        state: AgentState = {"agent_id": "a1", "messages": []}
+        msg: Message = {"role": "user", "content": "Hello", "timestamp": 123.0}
+        new_state = add_message(state, msg)
+        self.assertEqual(len(new_state["messages"]), 1)
+        self.assertEqual(new_state["messages"][0]["content"], "Hello")
+
+    def test_merge_outputs(self):
+        state: AgentState = {"outputs": [1]}
+        new_state = merge_outputs(state, [2, 3])
+        self.assertEqual(new_state["outputs"], [1, 2, 3])
+
+    def test_update_progress(self):
+        state: AgentState = {"progress": 0.1}
+        new_state = update_progress(state, 0.5)
+        self.assertEqual(new_state["progress"], 0.5)
+
+    def test_add_tool_result(self):
+        state: AgentState = {"tool_results": {"t1": "old"}}
+        new_state = add_tool_result(state, "t2", "new")
+        self.assertEqual(new_state["tool_results"]["t2"], "new")
+
+    def test_add_inter_agent_message(self):
+        state: AgentState = {"inter_agent_comm": []}
+        msg: Message = {"role": "agent", "content": "Ping", "timestamp": 456.0}
+        new_state = add_inter_agent_message(state, msg)
+        self.assertEqual(len(new_state["inter_agent_comm"]), 1)
+        self.assertEqual(new_state["inter_agent_comm"][0]["content"], "Ping")
+
+    def test_add_update(self):
+        state: AgentState = {"updates": []}
+        new_state = add_update(state, {"foo": "bar"})
+        self.assertEqual(new_state["updates"][0]["foo"], "bar")
+
+    def test_add_agent(self):
+        system_state: SystemState = {"agents": {}}
+        agent_state: AgentState = {"agent_id": "a1"}
+        new_state = add_agent(system_state, "a1", agent_state)
+        self.assertIn("a1", new_state["agents"])
+
+    def test_serialize_deserialize(self):
+        system_state: SystemState = {
+            "agents": {"a1": {"agent_id": "a1", "messages": []}},
+            "progress_board": [],
+            "updates": []
+        }
+        s = serialize_state(system_state)
+        restored = deserialize_state(s)
+        self.assertEqual(restored["agents"]["a1"]["agent_id"], "a1")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
 Add Unit Tests for State Reducers

What
- Added `test_state_reducers.py` with unit tests for all reducer functions and serialization/deserialization in the core state management module.

 Why
- Ensures correctness of state update logic and checkpointing.
- Provides a foundation for safe refactoring and future development.

 How to Run

From your project root, run:

    python -m unittest multiagenticswarm/core/test_state_reducers.py


All tests should pass if the reducers and serialization are working correctly.